### PR TITLE
Disabled test during makepkg

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-ackermann-steering-controller
 	pkgdesc = ROS - Controller for a steer drive mobile base.
 	pkgver = 0.17.0
-	pkgrel = 2
+	pkgrel = 1
 	url = http://wiki.ros.org/ackermann_steering_controller
 	arch = i686
 	arch = x86_64
@@ -32,8 +32,8 @@ pkgbase = ros-melodic-ackermann-steering-controller
 	depends = ros-melodic-realtime-tools
 	depends = ros-melodic-pluginlib
 	depends = boost
-	source = ros-melodic-ackermann-steering-controller-0.17.0-.tar.gz::https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ackermann_steering_controller/0.17.0-.tar.gz
-	sha256sums = 51080af6bb85aec200e53b327731f99e4df05bca13429348296b9d113ab86859
+	source = ros-melodic-ackermann-steering-controller-0.17.0.tar.gz::https://github.com/ros-controls/ros_controllers/archive/0.17.0.tar.gz
+	sha256sums = d1b46651956d19a36eedc628c2761526ec4769390e596bd76688abc45f59ace8
 
 pkgname = ros-melodic-ackermann-steering-controller
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-ackermann-steering-controller
 	pkgdesc = ROS - Controller for a steer drive mobile base.
 	pkgver = 0.17.0
-	pkgrel = 1
+	pkgrel = 2
 	url = http://wiki.ros.org/ackermann_steering_controller
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='http://wiki.ros.org/ackermann_steering_controller'
 pkgname='ros-melodic-ackermann-steering-controller'
 pkgver='0.17.0'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=2
+pkgrel=1
 license=('BSD')
 
 ros_makedepends=(
@@ -52,9 +52,9 @@ depends=(
 # sha256sums=('SKIP')
 
 # Tarball version (faster download)
-_dir="ros_controllers-release-release-melodic-ackermann_steering_controller"
-source=("${pkgname}-${pkgver}-${_pkgver_patch}.tar.gz"::"https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ackermann_steering_controller/${pkgver}-${_pkgver_patch}.tar.gz")
-sha256sums=('51080af6bb85aec200e53b327731f99e4df05bca13429348296b9d113ab86859')
+_dir="ros_controllers-${pkgver}/ackermann_steering_controller"
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-controls/ros_controllers/archive/${pkgver}.tar.gz")
+sha256sums=('d1b46651956d19a36eedc628c2761526ec4769390e596bd76688abc45f59ace8')
 
 build() {
   # Use ROS environment variables

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='http://wiki.ros.org/ackermann_steering_controller'
 pkgname='ros-melodic-ackermann-steering-controller'
 pkgver='0.17.0'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(
@@ -72,6 +72,7 @@ build() {
   cmake ${srcdir}/${_dir} \
           -DCMAKE_BUILD_TYPE=Release \
           -DCATKIN_BUILD_BINARY_PACKAGE=ON \
+          -DCATKIN_ENABLE_TESTING=0 \
           -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic \
           -DPYTHON_EXECUTABLE=/usr/bin/python3 \
           -DSETUPTOOLS_DEB_LAYOUT=OFF


### PR DESCRIPTION
This way we can avoid adding the test dependencies to the PKGBUILD

This makes #2 obsolete.